### PR TITLE
Specify docker-compose version 3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: "3"
 services:
   web:
     build: .


### PR DESCRIPTION
Version 3.x, the latest and recommended version, designed to be cross-compatible between Compose and the Docker Engine’s swarm mode. This is specified with a version: ‘3’ or version: ‘3.1’, etc., entry at the root of the YAML.

OS: Ubuntu
Docker compose version: 1.25

Without `version=""3`:
```
~/code/rails7:$ docker-compose build
ERROR: The Compose file './docker-compose.yml' is invalid because:
Unsupported config option for services: 'db'
Unsupported config option for volumes: 'redis_data'
```

With `version=""3`:
```
~/code/rails7:$ docker-compose build
db uses an image, skipping
redis uses an image, skipping
Building web
Step 1/8 : FROM ruby:3.1.2-slim
3.1.2-slim: Pulling from library/ruby
214ca5fb9032: Pull complete
.....
```
