### PR TITLE
Remove error_highlight

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,8 +67,6 @@ group :development do
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
-
-  gem "error_highlight", ">= 0.4.0", platforms: [:ruby]
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,6 @@ GEM
     diff-lcs (1.5.0)
     drb (2.2.0)
       ruby2_keywords
-    error_highlight (0.5.1)
     erubi (1.12.0)
     ffi (1.16.3)
     globalid (1.2.1)
@@ -319,7 +318,6 @@ DEPENDENCIES
   bundler-audit
   capybara
   debug
-  error_highlight (>= 0.4.0)
   image_processing (~> 1.2)
   importmap-rails
   jbuilder


### PR DESCRIPTION
On Ruby 3.2, this is not necessary.

https://github.com/rails/rails/blob/a7f1d63a3bf92e5c07400afefd6016cdf48208a2/Gemfile#L196